### PR TITLE
Update tusk.conf

### DIFF
--- a/install/templates/conf/tusk/tusk.conf
+++ b/install/templates/conf/tusk/tusk.conf
@@ -166,7 +166,7 @@
   "Security" : {
 	"CookieSecret"			: "mysecretword",
 	"CookieUsesUserID"		: "",
-	"RssSecret"			: "anothersecretword"
+	"RssSecret"			: "anothersecretword",
 	"ChecklistSecret"   		: "facultychecklistsecretword"
   },
 


### PR DESCRIPTION
tusk.conf is not valid json file when I ran it in jsonlint.com because 
there is no comma between "anothersecretword" and "ChecklistSecret"
